### PR TITLE
Fix docs mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Sometimes you may need to manipulate the Calendar from your parent component, yo
 - __event-created(event)__ - Triggered on select()
 - __event-receive(event)__ - Triggered on eventReceive()
 - __event-render(event)__ - Triggered on eventRender()
-- __view-render(event)__ - Triggered on viewRender()
+- __view-render(view, element)__ - Triggered on viewRender()
 - __day-click(date, jsEvent, view)__ - Triggered on dayClick()
 
 You can listen for these events using the following markup


### PR DESCRIPTION
In my previous PR https://github.com/CroudTech/vue-fullcalendar/pull/162 there was a mistake (a.k.a copy-paste) in the docs. The parameters passed to viewRender actually isn't an event, but the current view. Sorry.